### PR TITLE
restructure files to use variable for SRG inclusion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ansible.python.interpreterPath": "/opt/homebrew/bin/python3"
+}

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,8 @@
 ---
 # playbook
 
+
+
 - name: Configure Cisco NX-OS to RTR STIG
   hosts: all
   gather_facts: yes

--- a/roles/cisco-nexus-stig-role/tasks/SV-221076r999685_rule.yml
+++ b/roles/cisco-nexus-stig-role/tasks/SV-221076r999685_rule.yml
@@ -1,0 +1,22 @@
+# DISA SRG:       SRG-NET-000019-RTR-000007 
+# Severity:       low
+# Rule ID:        SV-221076r999685_rule
+# Identifiers:    SV-110971, V-101867, CCI-001414
+
+- name: "[SV-221076r999685_rule] Gather Port Status"
+  when: ansible_network_os == 'nxos'
+  cisco.nxos.nxos_command:
+    commands:
+      - show interface status | json
+  register: if_state
+
+- name: "[SV-221076r999685_rule] Set Description and Shutdown Unused Ports"
+  cisco.nxos.nxos_interfaces: 
+    config:
+      - name: '{{ item.interface }}'
+        description: "DISABLED - UNUSED"
+        enabled: false
+  loop: '{{ if_state.stdout[0].TABLE_interface.ROW_interface }}'
+  when: 
+    - item.state == 'notconnect' or item.state == 'xcvrAbsent'
+    - item.interface | length <= 11

--- a/roles/cisco-nexus-stig-role/tasks/SV-221078r999687_rule.yml
+++ b/roles/cisco-nexus-stig-role/tasks/SV-221078r999687_rule.yml
@@ -1,0 +1,15 @@
+# DISA SRG:       SRG-NET-000131-RTR-000083
+# Severity:       medium
+# Rule ID:        SV-221078r999687_rule
+# Identifiers:    SV-110975, V-101871, CCI-002403
+
+- name: >
+    SV-221078r999687_rule: The Cisco switch must not be configured to have any
+    feature enabled that calls home to the vendor
+  when: ansible_network_os == 'nxos'
+  cisco.nxos.nxos_config:
+    lines:
+      - '  no enable'
+    parents: callhome
+    match: exact
+    replace: line

--- a/roles/cisco-nexus-stig-role/tasks/main.yml
+++ b/roles/cisco-nexus-stig-role/tasks/main.yml
@@ -5,24 +5,24 @@
 #  hosts: ashburn-lab
 #  gather_facts: no
 
-- name: Enable NXAPI access with default configuration
-  nxos_nxapi:
-    state: present
-    enable_http: yes
-    enable_https: yes
+#- name: Enable NXAPI access with default configuration
+#  nxos_nxapi:
+#    state: present
+#    enable_http: yes
+#    enable_https: yes
 
-- name: Set NTP Server
-  when: ansible_network_os == 'nxos'
-  loop: "{{ ntp_servers }}"
-  nxos_config:
-    lines:
-      - ntp server {{ item }} use-vrf default
+#- name: Set NTP Server
+#  when: ansible_network_os == 'nxos'
+#  loop: "{{ ntp_servers }}"
+#  nxos_config:
+#    lines:
+#      - ntp server {{ item }} use-vrf default
 
-- name: "SV-221078r999687_rule: The Cisco switch must not be configured to have any feature enabled that calls home to the vendor"
-  when: ansible_network_os == 'nxos'
-  cisco.nxos.nxos_config:
-    lines:
-      - '  no enable'
-    parents: callhome
-    match: exact
-    replace: line
+
+- name: "SRG-NET-000019-RTR-000007"
+  include_tasks: SV-221076r999685_rule.yml
+  when: stig_rules.SRG_NET_000019_RTR_000007 | bool | default(true)
+
+- name: "SRG-NET-000131-RTR-000083"
+  include_tasks: SV-221078r999687_rule.yml
+  when: stig_rules.SRG_NET_000131_RTR_000083 | bool | default(true)

--- a/roles/cisco-nexus-stig-role/vars/main.yml
+++ b/roles/cisco-nexus-stig-role/vars/main.yml
@@ -3,3 +3,7 @@
 
 ntp_servers:
   - 8.8.8.8
+
+stig_rules:
+  SRG_NET_000131_RTR_000083: true
+  SRG_NET_000019_RTR_000007: true


### PR DESCRIPTION
* Adds a variable list to enable/disable SRG checks
* Scaffolding to knock out remaining rules

````

TASK [cisco-nexus-stig-role : SRG-NET-000019-RTR-000007] ***************************************************************************************************
included: /Users/shawnwells/Documents/github/cisco-nexus-stig-role/roles/cisco-nexus-stig-role/tasks/SV-221076r999685_rule.yml for 192.168.4.252

TASK [cisco-nexus-stig-role : [SV-221076r999685_rule] Gather Port Status] **********************************************************************************
ok: [192.168.4.252]

TASK [cisco-nexus-stig-role : [SV-221076r999685_rule] Set Description and Shutdown Unused Ports] ***********************************************************
skipping: [192.168.4.252] => (item={'interface': 'mgmt0', 'name': 'Link_To_E1/47_SwitchA', 'state': 'connected', 'vlan': 'routed', 'duplex': 'full', 'speed': '1000', 'type': '--'}) 
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/1', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/2', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/3', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/4', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/5', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/6', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/7', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/8', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
changed: [192.168.4.252] => (item={'interface': 'Ethernet1/9', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'})
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/10', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/11', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/12', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/13', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/14', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/15', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/16', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/17', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/18', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/19', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/20', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/21', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/22', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/23', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/24', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/25', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/26', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/27', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/28', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/29', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/30', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/31', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/32', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/33', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/34', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/35', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/36', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/37', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/38', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/39', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/40', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/41', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/42', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/43', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/44', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/45', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/46', 'state': 'notconnect', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '1000base-T'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/47', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/48', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/49', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/50', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/51', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/52', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/53', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 
skipping: [192.168.4.252] => (item={'interface': 'Ethernet1/54', 'state': 'xcvrAbsent', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '--'}) 

TASK [cisco-nexus-stig-role : SRG-NET-000131-RTR-000083] ***************************************************************************************************
included: /Users/shawnwells/Documents/github/cisco-nexus-stig-role/roles/cisco-nexus-stig-role/tasks/SV-221078r999687_rule.yml for 192.168.4.252

TASK [cisco-nexus-stig-role : SV-221078r999687_rule: The Cisco switch must not be configured to have any feature enabled that calls home to the vendor] ****
[WARNING]: To ensure idempotency and correct diff the input configuration lines should be similar to how they appear if present in the running
configuration on device
changed: [192.168.4.252]

PLAY RECAP *************************************************************************************************************************************************
192.168.4.252              : ok=6    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

````