### PR TITLE
disable ip directed broadcast rule

### DIFF
--- a/roles/cisco-nexus-stig-role/tasks/SV-221083r999692_rule.yml
+++ b/roles/cisco-nexus-stig-role/tasks/SV-221083r999692_rule.yml
@@ -1,0 +1,42 @@
+# DISA SRG:       SRG-NET-000362-RTR-000112
+# Severity:       low
+# Rule ID:        SV-221083r999692_rule
+# Identifiers:    SV-110985, V-101881, CCI-002385
+
+# NX-OS v7.x does not support the `no ip directed-broadcast` command
+# NX-OS v8.x+ does but it is (or should be) disabled by default
+# The rule checks to see if the command is available, but otherwise just logs for compliance
+
+- name: >
+    [SV-221083r999692_rule Step 1 of 3] Check if 'ip directed-broadcast' is supported (part 1)
+  cisco.nxos.nxos_command:
+    commands: "show running-config interface {{ external_interfaces[0] }}"
+  register: directed_broadcast_check
+  when: external_interfaces | length > 0
+
+- name: >
+    [SV-221083r999692_rule Step 2 of 3] Check if 'ip directed-broadcast' is supported (part 2)
+  set_fact:
+    directed_broadcast_supported: >-
+      {{
+        directed_broadcast_check.stdout[0]
+        | regex_search('ip directed-broadcast', ignorecase=True) is not none
+      }}
+  when: directed_broadcast_check is defined and directed_broadcast_check.stdout[0] is defined
+
+- name: >
+    [SV-221083r999692_rule Step 3a of 3] (Supported) Disable directed broadcast on all external interfaces
+  cisco.nxos.nxos_config:
+    lines:
+      - no ip directed-broadcast
+    parents: "interface {{ item }}"
+  loop: "{{ external_interfaces }}"
+  when: directed_broadcast_supported
+
+- name: >
+    [SV-221083r999692_rule Step 3b of 3] (Not supported) Skip for compliance awareness
+  debug:
+    msg: >
+      [!] 'ip directed-broadcast' command not supported or present on this NX-OS version.
+      Skipping SRG-NET-000362-RTR-000112 (Disable IP directed broadcast on all interfaces).
+  when: not directed_broadcast_supported

--- a/roles/cisco-nexus-stig-role/tasks/main.yml
+++ b/roles/cisco-nexus-stig-role/tasks/main.yml
@@ -52,3 +52,7 @@
 - name: "RG-NET-000364-RTR-000111"
   ansible.builtin.include_tasks: SV-221096r999705_rule.yml
   when: stig_rules.SRG_NET_000364_RTR_000111 | bool | default(true)
+
+- name: "SRG-NET-000362-RTR-000112"
+  ansible.builtin.include_tasks: SV-221083r999692_rule.yml
+  when: stig_rules.SRG_NET_000362_RTR_000112 | bool | default(true)

--- a/roles/cisco-nexus-stig-role/vars/main.yml
+++ b/roles/cisco-nexus-stig-role/vars/main.yml
@@ -33,7 +33,7 @@ stig_rules:
   SRG_NET_000512_RTR_000004: false
   SRG_NET_000078_RTR_000001: false
   SRG_NET_000512_RTR_000013: false
-
+  SRG_NET_000362_RTR_000112: false
 
 #
 # The `external_interfaces` variable is used to specify the interfaces


### PR DESCRIPTION
Ip directed broadcast isn't available as a command until v.8 and is disabled by default on that and subsequent versions
Following the same format as the one for the LLDP rule, this checks to see if the command is supported (and if so, disables (although it should be already)) and otherwise logs for compliance